### PR TITLE
feat(switch): experimental cooking mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,20 @@
 :grey_exclamation: I am in no way affiliated with Saleryd. All trademarks belong to their respective owners.
 
 ## Motivation
+
 Monitor and control HRV system from Home Assistant.
 
 ### Ideas for automations
+
 - `airflow/temperature/cooling based on presence/schedule.`
 - `cooling/temperature mode based on external temperature/humidity sensors or alarm system state`
 - `energy price integration`
 - `remote control using dashboard or physical controls`
 - `...`
 
-## Integration sensors
+## Features
+
+### Sensors
 
 Name | Description | Unit | State attributes
 -- | -- | -- | --
@@ -54,7 +58,7 @@ Name | Description | Unit | State attributes
 `ventilation_mode` | current ventilation mode setting | `str` |
 
 
-## Integration switches
+## Switches
 
 Switch | Description | State attributes
 -- | -- | --
@@ -72,6 +76,14 @@ Name | Description | Fields
 `set_fireplace_mode` | Set fireplace mode | value: `integer` (0=On, 1=Off)
 `set_temperature_mode` | Set temperature mode | value: `integer` (0=Normal,1=Economy,2=Cool)
 `set_ventilation_mode` | Set ventilation mode | value: `integer` (0=Home,1=Away,2=Boost)
+
+## Experimental features
+
+### Switches
+
+Switch | Description | State attributes
+-- | -- | --
+`cooking_mode` | Turn cooking mode on/off. Emulates cooking mode when fireplace mode is active. Automatically disables fireplace mode before timer expires to reset rotary heat exchanger to normal operation.
 
 ## Supported devices
 

--- a/custom_components/saleryd_hrv/__init__.py
+++ b/custom_components/saleryd_hrv/__init__.py
@@ -18,6 +18,10 @@ from .const import (
     CONF_WEBSOCKET_PORT,
     DOMAIN,
     PLATFORMS,
+    SERVICE_SET_COOLING_MODE,
+    SERVICE_SET_FIREPLACE_MODE,
+    SERVICE_SET_TEMPERATURE_MODE,
+    SERVICE_SET_VENTILATION_MODE,
     STARTUP_MESSAGE,
 )
 from .coordinator import SalerydLokeDataUpdateCoordinator
@@ -85,10 +89,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         _LOGGER.info("Sending set cooling mode request of %s", value)
         await control_request("MK", value)
 
-    hass.services.async_register(DOMAIN, "set_fireplace_mode", set_fireplace_mode)
-    hass.services.async_register(DOMAIN, "set_cooling_mode", set_cooling_mode)
-    hass.services.async_register(DOMAIN, "set_ventilation_mode", set_ventilation_mode)
-    hass.services.async_register(DOMAIN, "set_temperature_mode", set_temperature_mode)
+    hass.services.async_register(DOMAIN, SERVICE_SET_FIREPLACE_MODE, set_fireplace_mode)
+    hass.services.async_register(DOMAIN, SERVICE_SET_COOLING_MODE, set_cooling_mode)
+    hass.services.async_register(
+        DOMAIN, SERVICE_SET_VENTILATION_MODE, set_ventilation_mode
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_SET_TEMPERATURE_MODE, set_temperature_mode
+    )
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True

--- a/custom_components/saleryd_hrv/const.py
+++ b/custom_components/saleryd_hrv/const.py
@@ -36,9 +36,10 @@ If you have any issues with this you need to open an issue here:
 -------------------------------------------------------------------
 """
 
-# Other constants
+# Virtual keys, ie not present in data
 KEY_CLIENT_STATE = "*HRV_CLIENT_STATE"
 KEY_TARGET_TEMPERATURE = "*TARGET_TEMPERATURE"
+KEY_COOKING_MODE = "*COOKING_MODE"
 
 TEMPERATURE_MODE_NORMAL = 0
 TEMPERATURE_MODE_ECO = 1
@@ -55,5 +56,11 @@ SYSTEM_ACTIVE_MODE_ON = 1
 SYSTEM_ACTIVE_MODE_OFF = 0
 SYSTEM_ACTIVE_MODE_RESET = 2
 
-HEATER_ACTIVE_MODE_ON = 1
-HEATER_ACTIVE_MODE_OFF = 0
+MODE_ON = 1
+MODE_OFF = 0
+
+# Services
+SERVICE_SET_FIREPLACE_MODE = "set_fireplace_mode"
+SERVICE_SET_COOLING_MODE = "set_cooling_mode"
+SERVICE_SET_VENTILATION_MODE = "set_ventilation_mode"
+SERVICE_SET_TEMPERATURE_MODE = "set_temperature_mode"

--- a/custom_components/saleryd_hrv/entity.py
+++ b/custom_components/saleryd_hrv/entity.py
@@ -1,11 +1,32 @@
 """Entity"""
 
-from homeassistant.helpers.entity import DeviceInfo, EntityDescription
+from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
 from .const import DEFAULT_NAME, DOMAIN, MANUFACTURER
 from .coordinator import SalerydLokeDataUpdateCoordinator
+
+
+class SaleryLokeVirtualEntity(Entity):
+    """Virtual Entity base class"""
+
+    def __init__(
+        self,
+        entry_id,
+        entity_description: EntityDescription,
+    ) -> None:
+        self._id = entry_id
+        self.entity_description = entity_description
+        self._attr_name = entity_description.name
+        self._attr_unique_id = f"{entry_id}_{slugify(entity_description.name)}"
+        self._id = entry_id
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry_id)},
+            name=DEFAULT_NAME,
+            manufacturer=MANUFACTURER,
+        )
 
 
 class SalerydLokeEntity(CoordinatorEntity):

--- a/custom_components/saleryd_hrv/sensor.py
+++ b/custom_components/saleryd_hrv/sensor.py
@@ -25,13 +25,13 @@ from homeassistant.util import Throttle, slugify
 from .const import (
     DEFAULT_NAME,
     DOMAIN,
-    HEATER_ACTIVE_MODE_OFF,
-    HEATER_ACTIVE_MODE_ON,
     HEATER_MODE_HIGH,
     HEATER_MODE_LOW,
     ISSUE_URL,
     KEY_CLIENT_STATE,
     KEY_TARGET_TEMPERATURE,
+    MODE_OFF,
+    MODE_ON,
     SUPPORTED_FIRMWARES,
     SYSTEM_ACTIVE_MODE_OFF,
     SYSTEM_ACTIVE_MODE_ON,
@@ -59,7 +59,7 @@ class SalerydLokeSensor(SalerydLokeEntity, SensorEntity):
         entity_description: SensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
-        self.entity_id = f"sensor.${DEFAULT_NAME}_${slugify(entity_description.name)}"
+        self.entity_id = f"sensor.{DEFAULT_NAME}_{slugify(entity_description.name)}"
 
         super().__init__(coordinator, entry_id, entity_description)
 
@@ -152,9 +152,9 @@ class SalerydLokeSensor(SalerydLokeEntity, SensorEntity):
                 self._log_unknown_sensor_value(value)
 
         if self.entity_description.key == "MH":
-            if value == HEATER_ACTIVE_MODE_ON:
+            if value == MODE_ON:
                 return "On"
-            elif value == HEATER_ACTIVE_MODE_OFF:
+            elif value == MODE_OFF:
                 return "Off"
             else:
                 self._log_unknown_sensor_value(value)


### PR DESCRIPTION
Implementation of cooking mode to disable fireplace mode before fireplace timer expires. Cooking mode will restore rotary heat exchanger to normal operation after fireplace mode is deactivated.

![image](https://github.com/bj00rn/ha-saleryd-ftx/assets/10961167/f4981058-122f-487e-bc6d-9c9039e9cda2)


fixes #35 