### PR TITLE
feat: add services to set target temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Name | Description | Fields
 `set_ventilation_mode` | Set ventilation mode | value: `integer` (0=Home,1=Away,2=Boost)
 `set_system_active_mode` | Set system active mode. (Maintenance settings must be unlocked first) | value: `integer` (0=Off,1=On,2=Reset)
 `unlock_maintenance_settings` | Unlock maintenance settings | value: `text` (maintenance password)
+`set_target_temperature_normal` | Set target temperature for normal temperature mode. (Maintenance settings must be unlocked first) | value: `number` (temperature 10-30 degrees celcius)
+`set_target_temperature_cool` | Set target temperature for cool temperature mode. (Maintenance settings must be unlocked first) | value: `number` (temperature 10-30 degrees celcius)
+`set_target_temperature_economy` | Set target temperature for economy temperature mode. (Maintenance settings must be unlocked first) | value: `number` (temperature 10-30 degrees celcius)
 
 ## Experimental features
 

--- a/custom_components/saleryd_hrv/__init__.py
+++ b/custom_components/saleryd_hrv/__init__.py
@@ -22,6 +22,9 @@ from .const import (
     SERVICE_SET_COOLING_MODE,
     SERVICE_SET_FIREPLACE_MODE,
     SERVICE_SET_SYSTEM_ACTIVE_MODE,
+    SERVICE_SET_TARGET_TEMPERATURE_COOL,
+    SERVICE_SET_TARGET_TEMPERATURE_ECONOMY,
+    SERVICE_SET_TARGET_TEMPERATURE_NORMAL,
     SERVICE_SET_TEMPERATURE_MODE,
     SERVICE_SET_VENTILATION_MODE,
     SERVICE_UNLOCK_MAINTENANCE_SETTINGS,
@@ -100,6 +103,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         LOGGER.debug("Sending system active mode request of %s", value)
         await control_request("MP", value)
 
+    async def set_target_temperature_cool(call):
+        value = call.data.get("value")
+        LOGGER.debug("Sending set target temperature for cool mode of %s", value)
+        await control_request("TF", value)
+
+    async def set_target_temperature_normal(call):
+        value = call.data.get("value")
+        LOGGER.debug("Sending set target temperature for normal mode of %s", value)
+        await control_request("TD", value)
+
+    async def set_target_temperature_economy(call):
+        value = call.data.get("value")
+        LOGGER.debug("Sending set target temperature for economy mode of %s", value)
+        await control_request("TE", value)
+
     hass.services.async_register(DOMAIN, SERVICE_SET_FIREPLACE_MODE, set_fireplace_mode)
     hass.services.async_register(DOMAIN, SERVICE_SET_COOLING_MODE, set_cooling_mode)
     hass.services.async_register(
@@ -108,11 +126,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.services.async_register(
         DOMAIN, SERVICE_SET_TEMPERATURE_MODE, set_temperature_mode
     )
+
     hass.services.async_register(
         DOMAIN, SERVICE_SET_SYSTEM_ACTIVE_MODE, set_system_active_mode
     )
     hass.services.async_register(
         DOMAIN, SERVICE_UNLOCK_MAINTENANCE_SETTINGS, unlock_maintenance_settings
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_SET_TARGET_TEMPERATURE_NORMAL, set_target_temperature_normal
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_SET_TARGET_TEMPERATURE_COOL, set_target_temperature_cool
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_SET_TARGET_TEMPERATURE_ECONOMY, set_target_temperature_economy
     )
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))

--- a/custom_components/saleryd_hrv/const.py
+++ b/custom_components/saleryd_hrv/const.py
@@ -69,5 +69,8 @@ SERVICE_SET_VENTILATION_MODE = "set_ventilation_mode"
 SERVICE_SET_TEMPERATURE_MODE = "set_temperature_mode"
 SERVICE_UNLOCK_MAINTENANCE_SETTINGS = "unlock_maintenance_settings"
 SERVICE_SET_SYSTEM_ACTIVE_MODE = "set_system_active_mode"
+SERVICE_SET_TARGET_TEMPERATURE_COOL = "set_target_temperature_cool"
+SERVICE_SET_TARGET_TEMPERATURE_NORMAL = "set_target_temperature_normal"
+SERVICE_SET_TARGET_TEMPERATURE_ECONOMY = "set_target_temperature_economy"
 
 LOGGER: Logger = getLogger(__package__)

--- a/custom_components/saleryd_hrv/services.yaml
+++ b/custom_components/saleryd_hrv/services.yaml
@@ -80,3 +80,45 @@ unlock_maintenance_settings:
       selector:
         text:
           type: password
+set_target_temperature_normal:
+  name: Set normal target temperature
+  description: Set target temperature for normal temperature mode
+  fields:
+    value:
+      name: Value
+      description: target temperature
+      example: "18"
+      required: true
+      selector:
+        number:
+          min: 10
+          max: 30
+          mode: slider
+set_target_temperature_cool:
+  name: Set cool target temperature
+  description: Set target temperature for cool temperature mode
+  fields:
+    value:
+      name: Value
+      description: target temperature
+      example: "18"
+      required: true
+      selector:
+        number:
+          min: 10
+          max: 30
+          mode: slider
+set_target_temperature_economy:
+  name: Set economy target temperature
+  description: Set target temperature for economy temperature mode
+  fields:
+    value:
+      name: Value
+      description: target temperature
+      example: "18"
+      required: true
+      selector:
+        number:
+          min: 10
+          max: 30
+          mode: slider


### PR DESCRIPTION
Add services to set target temperature for each temperature mode. Unlock maintenance settings before calling